### PR TITLE
HACS compatibility : integration is in the root folder

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -3,5 +3,6 @@
   "homeassistant": "2024.1",
   "domains": ["alarm_control_panel", "binary_sensor", "button", "camera", "cover", "device_tracker", "sensor", "switch"],
   "iot_class": "local_polling",
-  "requirements": ["freebox-api>=1.2.2"]
+  "requirements": ["freebox-api>=1.2.2"],
+  "content_in_root": true
 }


### PR DESCRIPTION
## Description
The folder tree does not match what is expected by HACS (ROOT_OF_THE_REPO/custom_components/freebox_home).
A workaround is to add a keyword in hacs.json to tell that the integration is right at the top of the repo.
See https://hacs.xyz/docs/publish/integration/

## Type of Change
<!-- Mark the relevant option with an 'x' -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code quality improvement
- [ ] Translation update


## Testing
<!-- Describe how you tested your changes -->

- [X] Tested in Home Assistant
- [ ] Ran syntax validation (`python test_changes.py`)
- [ ] Ran unit tests (if applicable)
- [ ] Tested with Freebox hardware
- [ ] Verified no breaking changes
